### PR TITLE
Updated release task to append version to the jar file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ task release {
     dependsOn build
     doLast {
         def dirStr = buildDir.toString() + '/libs/'
-        file(dirStr + rootProject.name + '-' + version + '-SNAPSHOT.jar').renameTo(dirStr + rootProject.name + '.jar')
+        file(dirStr + rootProject.name + '-' + version + '-SNAPSHOT.jar').renameTo(dirStr + rootProject.name + '-' + version + '.jar')
     }
 }
 


### PR DESCRIPTION
Jar is being created like so in the automated release

![image](https://user-images.githubusercontent.com/38759683/92312991-4c3b4980-efbe-11ea-9c3d-20abb29c3f3f.png)

We should have it append the symantic versioning `v1.0.0` to the end.